### PR TITLE
Added tolerance for the lookup function

### DIFF
--- a/gsLookupFunction.h
+++ b/gsLookupFunction.h
@@ -16,6 +16,7 @@
 
 #include <gsCore/gsLinearAlgebra.h>
 #include <gsCore/gsGeometry.h>
+#include <gsCore/gsMath.h>
 
 namespace gismo
 {
@@ -105,17 +106,23 @@ public:
      * evaluating the function at the corresponding input point.
      *
      */
-    virtual void eval_into(const gsMatrix<T>& u, gsMatrix<T>& result) const
+    virtual void eval_into(const gsMatrix<T>& u, gsMatrix<T>& result) const override
     {
-        index_t col;
-        result.resize(this->targetDim(),u.cols());
-        result.setZero();
-        for (index_t k = 0; k!= u.cols(); k++)
-        {
+        const T tolerance = 100 * math::numeric_limits<T>::digits10(); 
 
-            GISMO_ASSERT(m_map.find(u.col(k))!=m_map.end(),"Coordinate " + std::to_string(k) + " not registered in the table");
-            col = m_map.at(u.col(k));
-            result.col(k) = m_data.col(col);
+        result.resize(this->targetDim(), u.cols());
+        result.setZero();
+
+        for (index_t k = 0; k != u.cols(); ++k)
+        {
+            auto it = std::find_if(m_map.begin(), m_map.end(),
+                [&](const std::pair<gsVector<T>, index_t>& entry) {
+                    return (entry.first - u.col(k)).norm() <= tolerance;
+                });
+
+            GISMO_ASSERT(it != m_map.end(),
+                "Coordinate " + util::to_string(k) + " [" + util::to_string(u.col(k).transpose()) + "] not registered in the table within tolerance.");
+            result.col(k) = m_data.col(it->second);
         }
     }
 

--- a/gsPreCICE.h
+++ b/gsPreCICE.h
@@ -47,6 +47,7 @@
 
 #include <gsCore/gsConfig.h>
 #include <precice/precice.hpp>
+#include <gsCore/gsMath.h>
 
 namespace gismo {
 
@@ -302,30 +303,22 @@ public:
      */
     void getMeshVertexIDsFromPositions(const std::string & meshName, const gsMatrix<T> & coords, gsVector<index_t> & IDs) const
     {
-        GISMO_ASSERT(coords.rows()==m_meshDims.at(meshName),"Dimension of the points ("<<coords.rows()<<") is not equal to the dimension of mesh "<<meshName<<"("<<m_meshDims.at(meshName)<<")\n");
+        GISMO_ASSERT(coords.rows() == m_meshDims.at(meshName), "Dimension of the points (" << coords.rows() << ") is not equal to the dimension of mesh " << meshName << " (" << m_meshDims.at(meshName) << ")\n");
         IDs.resize(coords.cols());
-        const std::map<gsVector<T>,index_t,mapCompare> & map = m_maps.at(this->getMeshID(meshName));
-        T tolerance = 1e-6; // Define a tolerance for coordinate comparison
-
-        for (index_t k=0; k!=coords.cols(); k++)
-    #ifdef  NDEBUG
-            IDs.at(k) = map.at(coords.col(k));
-    #else
+        const std::map<gsVector<T>, index_t, mapCompare> & map = m_maps.at(this->getMeshID(meshName));
+        const T tolerance = 100 * math::numeric_limits<T>::digits10(); // Adjusted tolerance for coordinate comparison
+    
+        for (index_t k = 0; k != coords.cols(); ++k)
         {
-            bool found = false;
-            for (const auto& entry : map)
-            {
-                if ((entry.first - coords.col(k)).norm() < tolerance)
-                {
-                    IDs.at(k) = entry.second;
-                    found = true;
-                    break;
-                }
-            }
-            GISMO_ASSERT(found, "Coordinate " << coords.col(k).transpose() << " is not registered in the vertex ID map of mesh " << meshName << ".\nThis error could be because you registered points in the parametric domain for the mesh, but you try to read (i.e. evaluate) points defined in the physical domain or vice versa.");
+            typename std::map<gsVector<T>, index_t, mapCompare>::const_iterator it = std::find_if(map.begin(), map.end(),
+                [&](const std::pair<gsVector<T>, index_t>& entry) {
+                    return (entry.first - coords.col(k)).norm() < tolerance;
+                });
+            GISMO_ASSERT(it != map.end(), "Coordinate " << coords.col(k).transpose() << " is not registered in the vertex ID map of mesh " << meshName << ".\nThis error could be because you registered points in the parametric domain for the mesh, but you try to read (i.e. evaluate) points defined in the physical domain or vice versa.");
+            IDs[k] = it->second;
         }
-    #endif
     }
+
 
     /**
      * @brief      Sets the mesh access region.

--- a/gsPreCICE.h
+++ b/gsPreCICE.h
@@ -300,22 +300,32 @@ public:
      * @param[in]  coords   The coordinates of the points
      * @param      IDs      The IDs of the points
      */
-    void getMeshVertexIDsFromPositions(const std::string & meshName, const gsMatrix<T> & coords, gsVector<index_t> & IDs) const
-    {
-        GISMO_ASSERT(coords.rows()==m_meshDims.at(meshName),"Dimension of the points ("<<coords.rows()<<") is not equal to the dimension of mesh "<<meshName<<"("<<m_meshDims.at(meshName)<<")\n");
-        IDs.resize(coords.cols());
-        const std::map<gsVector<T>,index_t,mapCompare> & map = m_maps.at(this->getMeshID(meshName));
-        for (index_t k=0; k!=coords.cols(); k++)
+void getMeshVertexIDsFromPositions(const std::string & meshName, const gsMatrix<T> & coords, gsVector<index_t> & IDs) const
+{
+    GISMO_ASSERT(coords.rows()==m_meshDims.at(meshName),"Dimension of the points ("<<coords.rows()<<") is not equal to the dimension of mesh "<<meshName<<"("<<m_meshDims.at(meshName)<<")\n");
+    IDs.resize(coords.cols());
+    const std::map<gsVector<T>,index_t,mapCompare> & map = m_maps.at(this->getMeshID(meshName));
+    T tolerance = 1e-6; // Define a tolerance for coordinate comparison
+
+    for (index_t k=0; k!=coords.cols(); k++)
 #ifdef  NDEBUG
-            IDs.at(k) = map.at(coords.col(k));
+        IDs.at(k) = map.at(coords.col(k));
 #else
+    {
+        bool found = false;
+        for (const auto& entry : map)
         {
-            typename std::map<gsVector<T>,index_t,mapCompare>::const_iterator it = map.find(coords.col(k));
-            GISMO_ASSERT(it!=map.end(),"Coordinate "<<coords.col(k).transpose()<<" is not registered in the vertex ID map of mesh "<<meshName<<".\nThis error could be because you registered points in the parametric domain for the mesh, but you try to read (i.e. evaluate) points defined in the physical domain or vice versa.");
-            IDs.at(k) = it->second;
+            if ((entry.first - coords.col(k)).norm() < tolerance)
+            {
+                IDs.at(k) = entry.second;
+                found = true;
+                break;
+            }
         }
-#endif
+        GISMO_ASSERT(found, "Coordinate " << coords.col(k).transpose() << " is not registered in the vertex ID map of mesh " << meshName << ".\nThis error could be because you registered points in the parametric domain for the mesh, but you try to read (i.e. evaluate) points defined in the physical domain or vice versa.");
     }
+#endif
+}
 
     /**
      * @brief      Sets the mesh access region.

--- a/gsPreCICE.h
+++ b/gsPreCICE.h
@@ -300,32 +300,32 @@ public:
      * @param[in]  coords   The coordinates of the points
      * @param      IDs      The IDs of the points
      */
-void getMeshVertexIDsFromPositions(const std::string & meshName, const gsMatrix<T> & coords, gsVector<index_t> & IDs) const
-{
-    GISMO_ASSERT(coords.rows()==m_meshDims.at(meshName),"Dimension of the points ("<<coords.rows()<<") is not equal to the dimension of mesh "<<meshName<<"("<<m_meshDims.at(meshName)<<")\n");
-    IDs.resize(coords.cols());
-    const std::map<gsVector<T>,index_t,mapCompare> & map = m_maps.at(this->getMeshID(meshName));
-    T tolerance = 1e-6; // Define a tolerance for coordinate comparison
-
-    for (index_t k=0; k!=coords.cols(); k++)
-#ifdef  NDEBUG
-        IDs.at(k) = map.at(coords.col(k));
-#else
+    void getMeshVertexIDsFromPositions(const std::string & meshName, const gsMatrix<T> & coords, gsVector<index_t> & IDs) const
     {
-        bool found = false;
-        for (const auto& entry : map)
+        GISMO_ASSERT(coords.rows()==m_meshDims.at(meshName),"Dimension of the points ("<<coords.rows()<<") is not equal to the dimension of mesh "<<meshName<<"("<<m_meshDims.at(meshName)<<")\n");
+        IDs.resize(coords.cols());
+        const std::map<gsVector<T>,index_t,mapCompare> & map = m_maps.at(this->getMeshID(meshName));
+        T tolerance = 1e-6; // Define a tolerance for coordinate comparison
+
+        for (index_t k=0; k!=coords.cols(); k++)
+    #ifdef  NDEBUG
+            IDs.at(k) = map.at(coords.col(k));
+    #else
         {
-            if ((entry.first - coords.col(k)).norm() < tolerance)
+            bool found = false;
+            for (const auto& entry : map)
             {
-                IDs.at(k) = entry.second;
-                found = true;
-                break;
+                if ((entry.first - coords.col(k)).norm() < tolerance)
+                {
+                    IDs.at(k) = entry.second;
+                    found = true;
+                    break;
+                }
             }
+            GISMO_ASSERT(found, "Coordinate " << coords.col(k).transpose() << " is not registered in the vertex ID map of mesh " << meshName << ".\nThis error could be because you registered points in the parametric domain for the mesh, but you try to read (i.e. evaluate) points defined in the physical domain or vice versa.");
         }
-        GISMO_ASSERT(found, "Coordinate " << coords.col(k).transpose() << " is not registered in the vertex ID map of mesh " << meshName << ".\nThis error could be because you registered points in the parametric domain for the mesh, but you try to read (i.e. evaluate) points defined in the physical domain or vice versa.");
+    #endif
     }
-#endif
-}
 
     /**
      * @brief      Sets the mesh access region.


### PR DESCRIPTION
During the coupling with preCICE, there could be a small numerical differences (e.g., due to evaluation or rounding) cause the exact match to fail. Found this issue when running simulation with OpenFOAM.